### PR TITLE
Add flashy Lucky Wheel tweaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,14 @@ body {
   background:#f7f7f7;
 }
 
+#title {
+  font-family: "Comic Sans MS", "Trebuchet MS", cursive;
+  font-size: 3em;
+  color: #e67e22;
+  text-shadow: 2px 2px #fff, -2px -2px #ddd;
+  margin: 0 0 10px;
+}
+
 #wheelContainer {
   position: relative;
   width: 500px;
@@ -26,24 +34,25 @@ body {
 #arrow {
   position: absolute;
   left: 50%;
-  top: -20px;
+  top: -60px;
   transform: translateX(-50%);
-  width: 0;
-  height: 0;
-  border-left: 20px solid transparent;
-  border-right: 20px solid transparent;
-  border-bottom: 40px solid #e74c3c;
+  font-size: 60px;
 }
 
 #addForm { margin-top: 20px; }
+#addForm input {
+  padding: 10px;
+  font-size: 1.2em;
+}
 #addForm button,
 #resetButton {
   margin-left: 8px;
-  padding: 6px 12px;
+  padding: 10px 20px;
   border: none;
   border-radius: 4px;
   background: linear-gradient(135deg, #74b9ff, #0984e3);
   color: #fff;
+  font-size: 1.2em;
   cursor: pointer;
 }
 #optionList { list-style: none; padding: 0; margin-top:10px; }
@@ -77,11 +86,16 @@ body {
 }
 #modalOverlay .modal {
   background: #fff;
-  padding: 30px;
+  padding: 40px;
   border-radius: 10px;
   box-shadow: 0 4px 12px rgba(0,0,0,0.3);
-  font-size: 1.8em;
+  font-size: 2.2em;
   animation: pop 0.3s ease;
+}
+#modalOverlay .modal .icon {
+  font-size: 1.5em;
+  display: block;
+  margin-bottom: 10px;
 }
 
 @keyframes pop {
@@ -91,9 +105,10 @@ body {
 </style>
 </head>
 <body>
+<h1 id="title">Lucky Wheel</h1>
 <div id="wheelContainer">
   <canvas id="wheel" width="500" height="500"></canvas>
-  <div id="arrow"></div>
+  <div id="arrow">👇</div>
 </div>
 <form id="addForm">
   <input id="newItem" type="text" placeholder="Add option" required>

--- a/wheel.js
+++ b/wheel.js
@@ -72,9 +72,10 @@ function updateOptionList() {
   });
 }
 
-function showModal(msg) {
-  modalContent.textContent = msg;
+function showModal(option) {
+  modalContent.innerHTML = `<span class="icon">${option.icon}</span>${option.text}`;
   modalOverlay.style.display = 'flex';
+  startFireworks();
 }
 
 modalOverlay.addEventListener('click', () => {
@@ -84,7 +85,7 @@ modalOverlay.addEventListener('click', () => {
 function drawRouletteWheel() {
   const active = options.filter(o => o.active);
   const outsideRadius = 200;
-  const textRadius = 160;
+  const textRadius = 170;
   const insideRadius = 50;
 
   ctx.clearRect(0, 0, 500, 500);
@@ -110,6 +111,7 @@ function drawRouletteWheel() {
 
     ctx.save();
     ctx.fillStyle = 'black';
+    ctx.font = 'bold 24px sans-serif';
     ctx.translate(250 + Math.cos(angle + arc / 2) * textRadius,
                   250 + Math.sin(angle + arc / 2) * textRadius);
     ctx.rotate(angle + arc / 2 + Math.PI / 2);
@@ -160,7 +162,7 @@ function stopRotateWheel() {
   const result = active[index];
   const msg = 'Result: ' + result.text;
   resultDiv.textContent = msg;
-  showModal(msg);
+  showModal(result);
   stopSpinSound();
   playCelebrateSound();
 }
@@ -200,6 +202,60 @@ function playCelebrateSound(){
   gain.gain.setValueAtTime(0.1, audioCtx.currentTime);
   osc.start();
   osc.stop(audioCtx.currentTime + 0.5);
+}
+
+function startFireworks(){
+  const canvas = document.createElement('canvas');
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  canvas.style.position = 'fixed';
+  canvas.style.left = 0;
+  canvas.style.top = 0;
+  canvas.style.pointerEvents = 'none';
+  canvas.id = 'fireworks';
+  document.body.appendChild(canvas);
+  const fctx = canvas.getContext('2d');
+  const particles = [];
+  function burst(x,y){
+    for(let i=0;i<20;i++){
+      particles.push({
+        x:x,
+        y:y,
+        vx: Math.cos(i/20*Math.PI*2)*(Math.random()*3+2),
+        vy: Math.sin(i/20*Math.PI*2)*(Math.random()*3+2),
+        alpha:1,
+        color:`hsl(${Math.random()*360},70%,60%)`
+      });
+    }
+  }
+  for(let b=0;b<3;b++){
+    burst(Math.random()*canvas.width, Math.random()*canvas.height/2);
+  }
+  let frame=0;
+  function animate(){
+    fctx.clearRect(0,0,canvas.width,canvas.height);
+    particles.forEach(p=>{
+      p.x+=p.vx;
+      p.y+=p.vy;
+      p.vy+=0.05;
+      p.alpha-=0.01;
+    });
+    particles.filter(p=>p.alpha>0).forEach(p=>{
+      fctx.globalAlpha=p.alpha;
+      fctx.fillStyle=p.color;
+      fctx.beginPath();
+      fctx.arc(p.x,p.y,3,0,Math.PI*2);
+      fctx.fill();
+    });
+    fctx.globalAlpha=1;
+    frame++;
+    if(frame<200){
+      requestAnimationFrame(animate);
+    }else{
+      document.body.removeChild(canvas);
+    }
+  }
+  animate();
 }
 
 canvas.addEventListener('click', spin);


### PR DESCRIPTION
## Summary
- decorate page with a large "Lucky Wheel" heading
- enlarge input controls and modal dialog
- use a cute emoji pointer instead of the old arrow
- make wheel text larger
- show result icon in modal and trigger a simple fireworks effect

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685e7dc350ac8329bb6de3e998d9fea9