### PR TITLE
Improve popup sound and card shuffling

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@ body {
   font-size: 1.5em;
 }
 .card-face.front {
-  background: #fff;
+  background: var(--bg, #fff);
   border: 2px solid #ddd;
 }
 .card-face.back {


### PR DESCRIPTION
## Summary
- use `clap.wav` for popup sound
- match card front color with option color
- shuffle cards by swapping positions
- guard card click during animation

## Testing
- `npx eslint .` *(fails: no project)*


------
https://chatgpt.com/codex/tasks/task_b_685e93e307f88329a265edb01f732973