### PR TITLE
Add group management for saved wheel options

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,6 @@ and spin a wheel to randomly choose one.
 - Options can be toggled on/off without deletion
 - Each option is displayed with a random emoji icon
 - Results are shown in a pop-up modal
+- Save sets of options into named groups for later loading
 
 Open `index.html` in a browser or deploy it via GitHub Pages to use it.

--- a/index.html
+++ b/index.html
@@ -47,6 +47,7 @@ body {
   font-size: 1.2em;
 }
 #addForm button,
+#saveButton,
 #resetButton {
   margin-left: 8px;
   padding: 10px 20px;
@@ -73,7 +74,8 @@ body {
   border: none;
   cursor: pointer;
 }
-#resetButton { margin-top: 10px; }
+#resetButton,
+#saveButton { margin-top: 10px; }
 #menu {
   position: fixed;
   right: 20px;
@@ -111,6 +113,28 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
+}
+#groupPanel {
+  position: fixed;
+  left: 20px;
+  top: 40px;
+  background: #ffeaa7;
+  padding: 10px;
+  border-radius: 4px;
+  text-align: left;
+}
+#groupList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+#groupList li {
+  margin-bottom: 6px;
+  display: flex;
+  align-items: center;
+}
+#groupList button {
+  margin-left: 6px;
 }
 .card {
   width: 150px;
@@ -228,6 +252,11 @@ body {
   #menu.open #menuItems {
     display: flex;
   }
+  #groupPanel {
+    top: auto;
+    bottom: 20px;
+    left: 10px;
+  }
 }
 
 @keyframes pop {
@@ -237,6 +266,9 @@ body {
 </style>
 </head>
 <body>
+<div id="groupPanel">
+  <ul id="groupList"></ul>
+</div>
 <div id="menu">
   <button id="menuToggle">☰</button>
   <div id="menuItems">
@@ -255,6 +287,7 @@ body {
   <input id="newItem" type="text" placeholder="Add option" required>
   <button type="submit">Add</button>
 </form>
+<button id="saveButton">Save</button>
 <button id="resetButton">Reset</button>
 <ul id="optionList"></ul>
 <div id="modalOverlay"><div class="modal" id="modalContent"></div></div>

--- a/wheel.js
+++ b/wheel.js
@@ -14,6 +14,8 @@ const muteButton = document.getElementById('muteButton');
 const cardContainer = document.getElementById('cardContainer');
 const wheelContainer = document.getElementById('wheelContainer');
 const title = document.getElementById('title');
+const saveButton = document.getElementById('saveButton');
+const groupListEl = document.getElementById('groupList');
 
 function resizeCanvas(){
   canvas.width = wheelContainer.clientWidth;
@@ -90,6 +92,8 @@ let spinTimeTotal = 0;
 let audioCtx;
 let lastTickIndex = -1;
 
+let groups = JSON.parse(localStorage.getItem('wheelGroups') || '[]');
+
 function countActive(){
   return options.filter(o => o.active).length;
 }
@@ -135,6 +139,46 @@ function updateOptionList() {
 
     optionList.appendChild(li);
   });
+}
+
+function saveGroups(){
+  localStorage.setItem('wheelGroups', JSON.stringify(groups));
+}
+
+function updateGroupList(){
+  groupListEl.innerHTML = '';
+  groups.forEach((g, idx) => {
+    const li = document.createElement('li');
+    li.textContent = g.name;
+    const loadBtn = document.createElement('button');
+    loadBtn.textContent = 'Load';
+    loadBtn.addEventListener('click', () => loadGroup(idx));
+    const delBtn = document.createElement('button');
+    delBtn.textContent = 'x';
+    delBtn.addEventListener('click', () => deleteGroup(idx));
+    li.appendChild(loadBtn);
+    li.appendChild(delBtn);
+    groupListEl.appendChild(li);
+  });
+}
+
+function loadGroup(idx){
+  const grp = groups[idx];
+  if(!grp) return;
+  options = JSON.parse(JSON.stringify(grp.options));
+  arc = countActive() > 0 ? Math.PI * 2 / countActive() : Math.PI * 2;
+  saveOptions();
+  updateOptionList();
+  drawRouletteWheel();
+  if(cardContainer.style.display !== 'none'){
+    initCards();
+  }
+}
+
+function deleteGroup(idx){
+  groups.splice(idx,1);
+  saveGroups();
+  updateGroupList();
 }
 
 function showModal(option, index) {
@@ -515,6 +559,23 @@ menuToggle.addEventListener('click', function(){
   menu.classList.toggle('open');
 });
 
+saveButton.addEventListener('click', function(){
+  const name = prompt('Enter group name');
+  if(!name) return;
+  groups.push({ name, options: JSON.parse(JSON.stringify(options)) });
+  saveGroups();
+  updateGroupList();
+  options = [];
+  arc = countActive() > 0 ? Math.PI * 2 / countActive() : Math.PI * 2;
+  saveOptions();
+  updateOptionList();
+  drawRouletteWheel();
+  if(cardContainer.style.display !== 'none'){
+    initCards();
+  }
+});
+
 muteButton.textContent = muted ? '🔇' : '🔊';
 updateOptionList();
+updateGroupList();
 resizeCanvas();


### PR DESCRIPTION
## Summary
- add Save button and group list panel
- style group panel and buttons
- implement group save/load/delete logic in `wheel.js`
- document group feature in README

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_b_68613356fb4883298ad4a06f013378ae