### PR TITLE
Add save confirmation modal and playful font

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,16 +7,14 @@
 <!-- Removed Ant Design CSS -->
 <style>
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-               "Helvetica Neue", Arial, sans-serif;
+  font-family: "Comic Sans MS", "Comic Neue", "Chalkboard SE", cursive;
   text-align: center;
   padding: 20px;
   background:#f0f2f5;
 }
 
 #title {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-               "Helvetica Neue", Arial, sans-serif;
+  font-family: "Comic Sans MS", "Comic Neue", "Chalkboard SE", cursive;
   font-size: 3em;
   color: #007acc;
   text-shadow: 1px 1px #fff;
@@ -348,6 +346,19 @@ body {
         <div class="ant-modal-footer">
           <button id="groupNameCancel" class="ant-btn">Cancel</button>
           <button id="groupNameOk" class="ant-btn ant-btn-primary">OK</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<div id="saveConfirmModal" class="ant-modal-root" style="display:none;">
+  <div class="ant-modal-mask"></div>
+  <div class="ant-modal-wrap">
+    <div class="ant-modal" style="top:30vh;">
+      <div class="ant-modal-content">
+        <div class="ant-modal-body">Group saved!</div>
+        <div class="ant-modal-footer">
+          <button id="saveConfirmOk" class="ant-btn ant-btn-primary">OK</button>
         </div>
       </div>
     </div>

--- a/wheel.js
+++ b/wheel.js
@@ -20,6 +20,8 @@ const groupNameModal = document.getElementById('groupNameModal');
 const groupNameInput = document.getElementById('groupNameInput');
 const groupNameCancel = document.getElementById('groupNameCancel');
 const groupNameOk = document.getElementById('groupNameOk');
+const saveConfirmModal = document.getElementById('saveConfirmModal');
+const saveConfirmOk = document.getElementById('saveConfirmOk');
 
 function resizeCanvas(){
   canvas.width = wheelContainer.clientWidth;
@@ -106,6 +108,14 @@ function openGroupNameModal(){
 
 function closeGroupNameModal(){
   groupNameModal.style.display = 'none';
+}
+
+function openSaveConfirm(){
+  saveConfirmModal.style.display = 'block';
+}
+
+function closeSaveConfirm(){
+  saveConfirmModal.style.display = 'none';
 }
 
 function countActive(){
@@ -603,6 +613,14 @@ groupNameOk.addEventListener('click', function(){
     initCards();
   }
   closeGroupNameModal();
+  openSaveConfirm();
+});
+
+saveConfirmOk.addEventListener('click', closeSaveConfirm);
+saveConfirmModal.addEventListener('click', function(e){
+  if(e.target === saveConfirmModal || e.target.classList.contains('ant-modal-mask')){
+    closeSaveConfirm();
+  }
 });
 
 muteButton.textContent = muted ? '🔇' : '🔊';


### PR DESCRIPTION
## Summary
- switch fonts to a playful style
- show a confirmation modal after saving a group

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68613f36825083299d32d74702bd37c6