### PR TITLE
Fix save group modal overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -276,6 +276,17 @@ body {
   padding: 10px;
   box-shadow: 0 2px 6px rgba(0,0,0,0.1);
 }
+.ant-modal-root {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+}
 .ant-modal-root .ant-modal {
   border-radius: 12px;
 }

--- a/wheel.js
+++ b/wheel.js
@@ -102,7 +102,7 @@ let groups = JSON.parse(localStorage.getItem('wheelGroups') || '[]');
 
 function openGroupNameModal(){
   groupNameInput.value = '';
-  groupNameModal.style.display = 'block';
+  groupNameModal.style.display = 'flex';
   groupNameInput.focus();
 }
 
@@ -111,7 +111,7 @@ function closeGroupNameModal(){
 }
 
 function openSaveConfirm(){
-  saveConfirmModal.style.display = 'block';
+  saveConfirmModal.style.display = 'flex';
 }
 
 function closeSaveConfirm(){


### PR DESCRIPTION
## Summary
- overlay Save Group and Save Confirm modals over the wheel
- use flex display when showing the modals

## Testing
- `npm test` *(fails: could not find package.json)*
- `true`


------
https://chatgpt.com/codex/tasks/task_b_6861415d2f808329888ef9e8dba50e69