### PR TITLE
Enable icon editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,12 @@ and spin a wheel to randomly choose one.
 - Uses `window.crypto.getRandomValues` for stronger randomness
 
 Open `index.html` in a browser or deploy it via GitHub Pages to use it.
+
+## Icons
+
+The wheel uses the following emoji icons by default:
+
+🍀 🌟 🍭 🍉 🍣 🧩 🎈 🐱 🐶 🐻
+
+You can replace them by editing the `ICONS` array in `wheel.js` or by
+changing each option's icon directly in the list.

--- a/index.html
+++ b/index.html
@@ -315,6 +315,15 @@ body {
 #optionList li input[type="checkbox"] {
   margin-left: 6px;
 }
+#optionList li input[type="text"] {
+  margin-left: 6px;
+  width: 120px;
+}
+#optionList li .icon-input {
+  margin-left: 6px;
+  width: 32px;
+  text-align: center;
+}
 </style>
 </head>
 <body>

--- a/wheel.js
+++ b/wheel.js
@@ -147,10 +147,35 @@ function updateOptionList() {
     const li = document.createElement('li');
     li.style.background = getColor(index, options.length);
 
-    const span = document.createElement('span');
+    const iconInput = document.createElement('input');
+    iconInput.type = 'text';
+    iconInput.value = opt.icon;
+    iconInput.maxLength = 2;
+    iconInput.className = 'ant-input icon-input';
+    iconInput.addEventListener('input', () => {
+      opt.icon = iconInput.value;
+      saveOptions();
+      drawRouletteWheel();
+      if(cardContainer.style.display !== 'none') initCards();
+    });
+    li.appendChild(iconInput);
+
+    const textInput = document.createElement('input');
+    textInput.type = 'text';
+    textInput.value = opt.text;
+    textInput.className = 'ant-input';
+    textInput.addEventListener('input', () => {
+      opt.text = textInput.value;
+      saveOptions();
+      drawRouletteWheel();
+      if(cardContainer.style.display !== 'none') initCards();
+    });
+    li.appendChild(textInput);
+
+    const probSpan = document.createElement('span');
     const prob = opt.active && activeCount ? (100/activeCount).toFixed(1) : '0.0';
-    span.textContent = `${opt.icon} ${opt.text} - ${prob}%`;
-    li.appendChild(span);
+    probSpan.textContent = ` - ${prob}%`;
+    li.appendChild(probSpan);
 
     const toggle = document.createElement('input');
     toggle.type = 'checkbox';
@@ -178,6 +203,9 @@ function updateOptionList() {
 
     optionList.appendChild(li);
   });
+  if(cardContainer.style.display !== 'none') {
+    initCards();
+  }
 }
 
 function saveGroups(){


### PR DESCRIPTION
## Summary
- allow editing icons next to each option
- style icon input in option list
- document inline icon editing in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6861e99ac2d88329bd203e8f681abaa4