### PR TITLE
Enhance option list styling and icon display

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,6 +63,20 @@ body {
   color: #000;
   font-size: 1.2em;
 }
+#iconList {
+  margin-top: 8px;
+  font-size: 2em;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+#optionList li input[type="text"],
+#optionList li .icon-input {
+  background: rgba(255, 255, 255, 0.6);
+  border: none;
+  border-radius: 6px;
+  padding: 2px 4px;
+}
 #optionList button {
   margin-left: 8px;
   background: transparent;
@@ -351,6 +365,7 @@ body {
 <button id="saveButton" class="ant-btn">Save</button>
 <button id="resetButton" class="ant-btn">Reset</button>
 <ul id="optionList"></ul>
+<div id="iconList"></div>
 <div id="modalOverlay"><div class="modal" id="modalContent"></div></div>
 <div id="groupNameModal" class="ant-modal-root" style="display:none;">
   <div class="ant-modal-mask"></div>

--- a/wheel.js
+++ b/wheel.js
@@ -4,6 +4,7 @@ const addForm = document.getElementById('addForm');
 const newItemInput = document.getElementById('newItem');
 const resetButton = document.getElementById('resetButton');
 const optionList = document.getElementById('optionList');
+const iconList = document.getElementById('iconList');
 const modalOverlay = document.getElementById('modalOverlay');
 const modalContent = document.getElementById('modalContent');
 const menuWheel = document.getElementById('menuWheel');
@@ -206,6 +207,21 @@ function updateOptionList() {
   if(cardContainer.style.display !== 'none') {
     initCards();
   }
+  updateIconList();
+}
+
+function updateIconList(){
+  iconList.innerHTML = '';
+  const used = [];
+  options.forEach(o => {
+    if(!used.includes(o.icon)) used.push(o.icon);
+  });
+  used.forEach(ic => {
+    const span = document.createElement('span');
+    span.textContent = ic;
+    span.style.margin = '0 4px';
+    iconList.appendChild(span);
+  });
 }
 
 function saveGroups(){


### PR DESCRIPTION
## Summary
- tweak list input backgrounds to blend with option colors
- show all option icons under the list
- expose icon container in JS and update automatically

## Testing
- `node --check wheel.js`

------
https://chatgpt.com/codex/tasks/task_b_6861eca19058832988e4060004ea1b62