### PR TITLE
Avoid duplicate groups

### DIFF
--- a/wheel.js
+++ b/wheel.js
@@ -660,7 +660,8 @@ groupNameOk.addEventListener('click', function(){
     closeGroupNameModal();
     return;
   }
-  const existingIdx = groups.findIndex(g => g.name === name);
+  const normalized = name.toLowerCase();
+  const existingIdx = groups.findIndex(g => g.name.trim().toLowerCase() === normalized);
   const groupData = { name, options: JSON.parse(JSON.stringify(options)) };
   if(existingIdx >= 0){
     groups[existingIdx] = groupData;


### PR DESCRIPTION
## Summary
- prevent duplicates by ignoring case when saving group names

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6870c05236288329b2b1e2467cb799ec